### PR TITLE
removing List_clear()

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -18,12 +18,6 @@ void List_destroy(List * list)
     free(list);
 }
 
-void List_clear(List *list)
-{
-    // only here for github example
-    
-}
-
 void List_push(List * list, void *value)
 {
     ListNode *node = calloc(1, sizeof(ListNode));


### PR DESCRIPTION
Removing List_Clear() because it is causing a Seg Fault. 

It is trying to free() a subset of a malloc created struct.  Trying to remove this part individually when the struct was created by itself causes an error.  

There is no reason to List_clear() either as, this functions purpose is to remove values, where as List_destroy() is designed to removed the nodes.  Becuase the nodes are created with malloc, the List_destroy()'s free() calls make sense. 

From Stack Overflow: 
As a rule of thumb for each malloc() there is a matching free(). No more, no less